### PR TITLE
Wrap return of findOrFail, takeOrFail in Optional<>

### DIFF
--- a/src/main/java/com/activepersistence/service/Querying.java
+++ b/src/main/java/com/activepersistence/service/Querying.java
@@ -1,11 +1,13 @@
 package com.activepersistence.service;
 
 import com.activepersistence.service.relation.QueryMethods.ValidUnscopingValues;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.persistence.EntityManager;
-import javax.persistence.Query;
+import java.util.Optional;
 
 public interface Querying<T> {
 
@@ -82,7 +84,7 @@ public interface Querying<T> {
         return all().take();
     }
 
-    public default T takeOrFail() {
+    public default Optional<T> takeOrFail() {
         return all().takeOrFail();
     }
 
@@ -90,7 +92,7 @@ public interface Querying<T> {
         return all().first();
     }
 
-    public default T firstOrFail() {
+    public default Optional<T> firstOrFail() {
         return all().firstOrFail();
     }
 
@@ -98,7 +100,7 @@ public interface Querying<T> {
         return all().last();
     }
 
-    public default T lastOrFail() {
+    public default Optional<T> lastOrFail() {
         return all().lastOrFail();
     }
 
@@ -126,7 +128,7 @@ public interface Querying<T> {
         return all().findBy(conditions);
     }
 
-    public default T findByOrFail(String conditions) {
+    public default Optional<T> findByOrFail(String conditions) {
         return all().findByOrFail(conditions);
     }
 
@@ -259,7 +261,7 @@ public interface Querying<T> {
     }
     //</editor-fold>
 
-    //<editor-fold defaultstate="collapsed" desc="Quering">
+    //<editor-fold defaultstate="collapsed" desc="Querying">
     public default List<T> findBySql(String sql) {
         return findBySql(sql, new HashMap());
     }

--- a/src/main/java/com/activepersistence/service/Querying.java
+++ b/src/main/java/com/activepersistence/service/Querying.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static java.util.Optional.ofNullable;
+
 public interface Querying<T> {
 
     public EntityManager getEntityManager();
@@ -116,7 +118,7 @@ public interface Querying<T> {
         return all().last(limit);
     }
 
-    public default T find(Object id) {
+    public default Optional<T> find(Object id) {
         return all().find(id);
     }
 

--- a/src/main/java/com/activepersistence/service/Relation.java
+++ b/src/main/java/com/activepersistence/service/Relation.java
@@ -5,21 +5,16 @@ import com.activepersistence.service.arel.DeleteManager;
 import com.activepersistence.service.arel.Entity;
 import com.activepersistence.service.arel.SelectManager;
 import com.activepersistence.service.arel.UpdateManager;
-import com.activepersistence.service.relation.Calculation;
-import com.activepersistence.service.relation.FinderMethods;
-import com.activepersistence.service.relation.QueryMethods;
-import com.activepersistence.service.relation.Scoping;
-import com.activepersistence.service.relation.SpawnMethods;
-import com.activepersistence.service.relation.Values;
+import com.activepersistence.service.relation.*;
+
+import javax.persistence.*;
 import java.util.List;
+import java.util.Optional;
+
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toList;
-import javax.persistence.EntityManager;
-import javax.persistence.LockModeType;
 import static javax.persistence.LockModeType.NONE;
 import static javax.persistence.LockModeType.PESSIMISTIC_READ;
-import javax.persistence.Query;
-import javax.persistence.TypedQuery;
 
 public class Relation<T> implements FinderMethods<T>, QueryMethods<T>, Calculation<T>, SpawnMethods<T>, Scoping<T> {
 
@@ -57,8 +52,8 @@ public class Relation<T> implements FinderMethods<T>, QueryMethods<T>, Calculati
         return buildQuery(toJpql()).getResultStream().findFirst().orElse(null);
     }
 
-    public T fetchOneOrFail() {
-        return buildQuery(toJpql()).getSingleResult();
+    public Optional<T> fetchOneOrFail() {
+        return optionalSingleResult(buildQuery(toJpql()));
     }
 
     public List<T> fetch() {
@@ -269,6 +264,14 @@ public class Relation<T> implements FinderMethods<T>, QueryMethods<T>, Calculati
                 && values.getGroupValues().isEmpty()
                 && values.getHavingValues().isEmpty()
                 && values.getJoinsValues().isEmpty();
+    }
+
+    private Optional<T> optionalSingleResult(TypedQuery<T> typedQuery) {
+        try {
+            return Optional.of(typedQuery.getSingleResult());
+        } catch (NoResultException nre) {
+            return Optional.empty();
+        }
     }
 
 }

--- a/src/main/java/com/activepersistence/service/relation/FinderMethods.java
+++ b/src/main/java/com/activepersistence/service/relation/FinderMethods.java
@@ -2,6 +2,7 @@ package com.activepersistence.service.relation;
 
 import com.activepersistence.service.Relation;
 import java.util.List;
+import java.util.Optional;
 
 public interface FinderMethods<T> {
 
@@ -13,7 +14,7 @@ public interface FinderMethods<T> {
         return thiz().limit(1).fetchOne();
     }
 
-    public default T takeOrFail() {
+    public default Optional<T> takeOrFail() {
         return thiz().limit(1).fetchOneOrFail();
     }
 
@@ -25,7 +26,7 @@ public interface FinderMethods<T> {
         return thiz().order(getPrimaryKey()).take();
     }
 
-    public default T firstOrFail() {
+    public default Optional<T> firstOrFail() {
         return thiz().order(getPrimaryKey()).takeOrFail();
     }
 
@@ -37,7 +38,7 @@ public interface FinderMethods<T> {
         return thiz().order(getPrimaryKey() + " DESC").take();
     }
 
-    public default T lastOrFail() {
+    public default Optional<T> lastOrFail() {
         return thiz().order(getPrimaryKey() + " DESC").takeOrFail();
     }
 
@@ -45,7 +46,7 @@ public interface FinderMethods<T> {
         return thiz().order(getPrimaryKey() + " DESC").take(limit);
     }
 
-    public default T find(Object id) {
+    public default Optional<T> find(Object id) {
         return thiz().where(getPrimaryKey() + " = :_id").bind("_id", id).takeOrFail();
     }
 
@@ -57,7 +58,7 @@ public interface FinderMethods<T> {
         return thiz().where(conditions).take();
     }
 
-    public default T findByOrFail(String conditions, Object... params) {
+    public default Optional<T> findByOrFail(String conditions, Object... params) {
         return thiz().where(conditions).takeOrFail();
     }
 

--- a/src/test/java/com/activepersistence/service/cases/RelationTest.java
+++ b/src/test/java/com/activepersistence/service/cases/RelationTest.java
@@ -88,7 +88,7 @@ public class RelationTest extends IntegrationTest {
     @Test
     public void testUpdateAll() {
         assertEquals(3, postsService.where("this.id IN (1,2,3)").updateAll("this.title = 'testing'"));
-        assertEquals("testing", postsService.find(1).getTitle());
+        assertEquals("testing", postsService.find(1).get().getTitle());
     }
 
     @Test

--- a/src/test/java/com/activepersistence/service/cases/relation/FinderMethodsTest.java
+++ b/src/test/java/com/activepersistence/service/cases/relation/FinderMethodsTest.java
@@ -28,7 +28,7 @@ public class FinderMethodsTest extends IntegrationTest {
 
     @Test
     public void testTakeOrFail() {
-        assertThrows(NoResultException.class, postsService.where("1=0")::takeOrFail);
+        assertFalse(postsService.where("1=0").takeOrFail().isPresent());
     }
 
     @Test
@@ -53,12 +53,12 @@ public class FinderMethodsTest extends IntegrationTest {
 
     @Test
     public void testLastOrFail() {
-        assertThrows(NoResultException.class, postsService.where("1=0")::lastOrFail);
+        assertFalse(postsService.where("1=0").lastOrFail().isPresent());
     }
 
     @Test
     public void testFind() {
-        assertEquals((Integer) 2, postsService.find(2).getId());
+        assertEquals((Integer) 2, postsService.find(2).get().getId());
     }
 
     @Test

--- a/src/test/java/com/activepersistence/service/cases/relation/QueryMethodsTest.java
+++ b/src/test/java/com/activepersistence/service/cases/relation/QueryMethodsTest.java
@@ -150,13 +150,13 @@ public class QueryMethodsTest extends IntegrationTest {
 
     @Test
     public void testOrdinalBindWithModel() {
-        Post postOne = postsService.find(1);
+        Post postOne = postsService.find(1).get();
         assertNotNull(postsService.where("this.id = ?1").bind(1, postOne));
     }
 
     @Test
     public void testPlaceholderBindWithModel() {
-        Post postOne = postsService.find(1);
+        Post postOne = postsService.find(1).get();
         assertNotNull(postsService.where("this.id = :id").bind("id", postOne));
     }
 


### PR DESCRIPTION
Wrapped the return of some query methods in an Optional, rather than to throw an Exception